### PR TITLE
Fix TypeScript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare namespace FeathersReactive {
 }
 
 declare module 'feathers' {
-  interface Service<T extends any> {
+  interface Service<T> {
     watch(): ReactiveService<T>
   }
 


### PR DESCRIPTION
TypeScript declarations are inconsistent between packages. Compiling throws an error `All declarations of 'Service' must have identical type parameters.`

There were 2 separate changes in `Service` declaration:
- https://github.com/feathersjs-ecosystem/feathers-reactive/pull/69 (and 2 other relevant packages referenced there)
- https://github.com/feathersjs/feathers/pull/692 and https://github.com/feathersjs-ecosystem/feathers-hooks/pull/173

Most recent change didn't update this package.

Linking https://github.com/feathersjs-ecosystem/feathers-hooks/issues/172 as well for possible future search of this problem.