### PR TITLE
Remove rxjs import from 0.5 configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ app.configure(reactive(Rx, { ...options }));
 0.5:
 ```js
 const reactive = require('feathers-reactive');
-const Rx = require('rxjs');
 // ...
 app.configure(reactive({ idField: 'id' /* depends on your DB */ , ...options }));
 ```


### PR DESCRIPTION
The documentation says that this line is no longer needed.