### PR TITLE
Omit all $ top level properties and export sift instance

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -1,6 +1,6 @@
 import stringify from 'json-stable-stringify';
-import {ReplaySubject} from 'rxjs/ReplaySubject';
-import {finalize, multicast, refCount} from 'rxjs/operators';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { finalize, multicast, refCount } from 'rxjs/operators';
 
 import _debug from 'debug';
 const debug = _debug('feathers-reactive');

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { fromEvent } from 'rxjs/observable/fromEvent';
 import reactiveResource from './resource';
 import reactiveList from './list';
 import strategies from './strategies';
-import { makeSorter, getParamsPosition, siftMatcher } from './utils';
+import { makeSorter, getParamsPosition, siftMatcher, sift } from './utils';
 
 const debug = _debug('feathers-reactive');
 
@@ -103,5 +103,6 @@ function FeathersRx (options = {}) {
 }
 
 FeathersRx.strategy = strategies;
+FeathersRx.sift = sift;
 
 module.exports = FeathersRx;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,6 @@
 import sift from 'sift';
-
-import {_, sorter as createSorter} from '@feathersjs/commons/lib/utils';
-
-import {defer} from 'rxjs/observable/defer';
+import { _, sorter as createSorter } from '@feathersjs/commons/lib/utils';
+import { defer } from 'rxjs/observable/defer';
 
 function getSource (originalMethod, args) {
   return defer(() => originalMethod(...args));
@@ -62,12 +60,14 @@ function getParamsPosition (method) {
 }
 
 function siftMatcher (originalQuery) {
-  const query = _.omit(originalQuery, '$limit', '$skip', '$sort', '$select');
+  const keysToOmit = Object.keys(originalQuery).filter(key => key.charCodeAt(0) === 36);
+  const query = _.omit(originalQuery, ...keysToOmit);
 
   return sift(query);
 }
 
 Object.assign(exports, {
+  sift,
   getSource,
   makeSorter,
   getOptions,

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -261,8 +261,13 @@ describe('reactive lists', () => {
       }, 20);
     });
 
-    it('.find with $sort, .create and .patch', done => {
-      const result = service.watch().find({ query: { $sort: { text: -1 } } });
+    it('.find with $sort, .create and .patch, omits $ properties', done => {
+      const result = service.watch().find({
+        query: {
+          $sort: { text: -1 },
+          $populate: 'something'
+        }
+      });
 
       result.pipe(
         skip(1),
@@ -319,8 +324,8 @@ describe('reactive lists', () => {
         const result = service.watch().find({ query: { counter: 1 } });
 
         result.pipe(first()).subscribe(messages =>
-            assert.deepEqual(messages, createdMessages),
-          done);
+          assert.deepEqual(messages, createdMessages),
+        done);
 
         result.pipe(skip(1), first()).subscribe(messages => {
           assert.deepEqual(messages, [{
@@ -351,8 +356,8 @@ describe('reactive lists', () => {
         const result = service.watch().find({ query: { counter: 1 } });
 
         result.pipe(first()).subscribe(messages =>
-            assert.deepEqual(messages, createdMessages),
-          done);
+          assert.deepEqual(messages, createdMessages),
+        done);
 
         result.pipe(skip(2), first()).subscribe(messages => {
           assert.deepEqual(messages, [{


### PR DESCRIPTION
This pull request omits all top level properties that start with a `$` and exports the `sift` instance that allows to add [custom expressions](https://github.com/crcn/sift.js#custom-expressions):

```js
const feathersRx = require('feathers-reactive');

feathersRx.sift.use({
  $search(a, b) {
    return (a & b) ? 0 : -1; // 0 = exists, -1 = doesn't exist
  }
});
```

- Closes https://github.com/feathersjs-ecosystem/feathers-reactive/issues/60
- Closes https://github.com/feathersjs-ecosystem/feathers-reactive/issues/56
- Closes https://github.com/feathersjs-ecosystem/feathers-reactive/issues/53

