### PR TITLE
Make options.pipe take single or multiple operators, fix typings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following options are supported:
 - `listStrategy` (default: `smart`): The strategy to use for streaming the data. Can be `smart`, `always` or `never`
 - `sorter` (`function(query, options) {}`): A function that returns a sorting function for the given query and option including pagination and limiting. Does not need to be customized unless there is a sorting mechanism other than Feathers standard in place.
 - `matcher` (`function(query)`): A function that returns a function which returns whether an item matches the original query or not.
-- `pipe` (`function(observable) => observable`) A function that lets you modify every `Observable` created by reactive service calls. Must return an `Observable`. Example: `pipe: observable => observable.do(console.log)` 'injects' a `.do` into the observable chain.
+- `pipe` (`operator | operator[]`) One or multiple rxjs operators of the form `function(observable) => observable` like you would pass them to an Observable's [.pipe method](https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md). The supplied operators are applied to any Observable created by `feathers-reactive`. `options.pipe: tap(data => console.log(data))` would log every emitted value to the console. 
 
 #### Application level
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,13 @@
+// Type definitions for feathers-reactive 0.5
+// Project: https://github.com/feathersjs-ecosystem/feathers-reactive
+// Definitions by: Jan Lohage <https://github.com/j2L4e>
+// Definitions: https://github.com/feathersjs-ecosystem/feathers-reactive
+
+// TypeScript Version: 2.1
+
 import { Observable } from 'rxjs/Observable';
 import { NullableId, Paginated, Params } from '@feathersjs/feathers';
+import { OperatorFunction } from 'rxjs/interfaces';
 
 declare function FeathersReactive(options: FeathersReactive.Options): () => void;
 export = FeathersReactive;
@@ -8,25 +16,25 @@ declare namespace FeathersReactive {
   type ListStrategy = any;
 
   // TODO: check for completeness
-  interface Options<S extends { [name: string]: ListStrategy }> {
-    idField: string,
-    dataField?: string,
-    sorter?: (query: any, options: any) => any,
+  interface Options {
+    idField: string;
+    dataField?: string;
+    sorter?: (query: any, options: any) => any;
 
     /**
      * a filter function factory
      */
-    matcher?: (query: any) => (element: any) => boolean,
+    matcher?: (query: any) => (element: any) => boolean;
 
-    listStrategies?: S,
-    listStrategy?: 'always' | 'smart' | 'never' | keyof S,
-    let?: (obs: Observable<any>) => Observable<any>
+    listStrategies?: { [name: string]: ListStrategy };
+    listStrategy?: 'always' | 'smart' | 'never' | string | ListStrategy;
+    pipe?: OperatorFunction<any, any> | Array<OperatorFunction<any, any>>;
   }
 }
 
 declare module '@feathersjs/feathers' {
   interface ServiceAddons<T> {
-    watch(options?: Partial<FeathersReactive.Options>): ReactiveService<T>
+    watch(options?: Partial<FeathersReactive.Options>): ReactiveService<T>;
   }
 
   interface ReactiveService<T> {
@@ -34,7 +42,7 @@ declare module '@feathersjs/feathers' {
      * Retrieves a list of all resources from the service.
      * Provider parameters will be passed as params.query
      */
-    find(params?: Params): Observable<Array<T> | Paginated<T>>;
+    find(params?: Params): Observable<T[] | Paginated<T>>;
 
     /**
      * Retrieves a single resource with the given id from the service.
@@ -44,7 +52,7 @@ declare module '@feathersjs/feathers' {
     /**
      * Creates a new resource with data.
      */
-    create(data: Partial<Array<T>>, params?: Params): Observable<Array<T>>;
+    create(data: Partial<T[]>, params?: Params): Observable<T[]>;
     create(data: Partial<T>, params?: Params): Observable<T>;
 
     /**

--- a/src/list.js
+++ b/src/list.js
@@ -1,6 +1,7 @@
 import {
   getOptions,
-  getSource
+  getSource,
+  getPipeStream
 } from './utils';
 
 import {
@@ -21,9 +22,9 @@ module.exports = function (settings) {
     const source = getSource(this.find.bind(this), arguments);
     const stream = options.listStrategy.call(this, source, options, arguments);
 
-    const letStream = options.pipe ? stream.pipe(options.pipe) : stream;
+    const pipeStream = getPipeStream(stream, options);
 
     // set cache and return cached observable
-    return cacheObservable(this._cache, 'find', params, letStream);
+    return cacheObservable(this._cache, 'find', params, pipeStream);
   };
 };

--- a/src/resource.js
+++ b/src/resource.js
@@ -1,7 +1,8 @@
 import {
   getOptions,
   getSource,
-  getParamsPosition
+  getParamsPosition,
+  getPipeStream
 } from './utils';
 
 import {
@@ -61,8 +62,7 @@ module.exports = function (settings, method) {
         );
       }));
 
-    // apply `let` function if set
-    const pipeStream = options.pipe ? stream.pipe(options.pipe) : stream;
+    const pipeStream = getPipeStream(stream, options);
 
     // if the method is `get` cache the result, otherwise just return the stream
     return method === 'get' ? cacheObservable(this._cache, 'get', /* id */ arguments[0], pipeStream) : pipeStream;

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,6 +46,16 @@ function getOptions (base, ...others) {
   return options;
 }
 
+function getPipeStream (stream, options) {
+  if (!options.pipe) {
+    return stream;
+  } else if (Array.isArray(options.pipe)) {
+    return stream.pipe(...options.pipe);
+  } else {
+    return stream.pipe(options.pipe);
+  }
+}
+
 function getParamsPosition (method) {
   // The position of the params parameters for a service method so that we can extend them
   // default is 1
@@ -72,5 +82,6 @@ Object.assign(exports, {
   makeSorter,
   getOptions,
   getParamsPosition,
-  siftMatcher
+  siftMatcher,
+  getPipeStream
 });

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -525,9 +525,24 @@ describe('reactive lists', () => {
       setTimeout(() => service.patch(0, { text }));
     });
 
-    it('injects options.pipe into observable chain', done => {
+    it('injects options.pipe into observable chain (single operator)', done => {
       const options = {
         pipe: tap(() => done())
+      };
+      service.watch(options).find().pipe(first()).subscribe();
+    });
+
+    it('injects options.pipe into observable chain (array of operators)', done => {
+      let i = 0;
+
+      const options = {
+        pipe: [
+          tap(() => i++),
+          tap(() => {
+            assert.equal(i, 1);
+            done();
+          })
+        ]
       };
       service.watch(options).find().pipe(first()).subscribe();
     });

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -179,9 +179,24 @@ describe('reactive resources', () => {
       setTimeout(() => service.remove(id));
     });
 
-    it('injects options.pipe into observable chain', done => {
+    it('injects options.pipe into observable chain (single operator)', done => {
       const options = {
         pipe: tap(() => done())
+      };
+      service.watch(options).get(0).pipe(take(1)).subscribe();
+    });
+
+    it('injects options.pipe into observable chain (array of operators)', done => {
+      let i = 0;
+
+      const options = {
+        pipe: [
+          tap(() => i++),
+          tap(() => {
+            assert.equal(i, 1);
+            done();
+          })
+        ]
       };
       service.watch(options).get(0).pipe(take(1)).subscribe();
     });


### PR DESCRIPTION
Makes options.pipe take a single operator or an array of operators, also contains properly linted typings.