### PR TITLE
Add missing rx function type to Feathers Service

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ declare namespace FeathersReactive {
 declare module '@feathersjs/feathers' {
   interface ServiceAddons<T> {
     watch(options?: Partial<FeathersReactive.Options>): ReactiveService<T>;
+    rx(options?: Partial<FeathersReactive.Options>): Service<T>;
   }
 
   interface ReactiveService<T> {


### PR DESCRIPTION
This adds the `rx` function type to the feathers service interface.