### PR TITLE
update link to API docs of rxjs 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## About
 
-`feathers-reactive` adds a `watch()` method to services. The returned object implements all service methods as [RxJS](https://github.com/Reactive-Extensions/RxJS) observables that automatically update on [real-time events](https://docs.feathersjs.com/api/events.html#service-events).
+`feathers-reactive` adds a `watch()` method to services. The returned object implements all service methods as [RxJS v6](https://github.com/ReactiveX/rxjs/tree/6.x) observables that automatically update on [real-time events](https://docs.feathersjs.com/api/events.html#service-events).
 
 ## Options
 


### PR DESCRIPTION
When clicking the link to rxjs, it shows read only with a link to the new repository. But master is for v7 beta, and the `package.json` on this uses v6. Hence, the direct link to the v6 version.