### PR TITLE
fix: Hook generating patched/updated event before created event generates doublons (closes #182)

### DIFF
--- a/src/strategies.js
+++ b/src/strategies.js
@@ -87,20 +87,16 @@ module.exports = function () {
         return page => {
           const isPaginated = !!page[options.dataField];
           const length = isPaginated ? page[options.dataField].length : page.length;
-          const process = data =>
-            data.filter(current => eventData[options.idField] !== current[options.idField])
-              .concat(eventData)
-              .filter(matches);
-          /* Why this does not actually work ?
           const process = data => {
             // Remove previous matching object if any
             let newData = data.filter(current => eventData[options.idField] !== current[options.idField]);
-            // We should not add object we are not already aware of however
-            if (newData.length < data.length) {
+            // We should not add object we are not already aware of
+            // except if update has changed it from an unmatched to a matched object
+            if ((newData.length < data.length) || matches([eventData])) {
               newData = newData.concat(eventData);
             }
             return newData.filter(matches);
-          }*/
+          }
 
           if (isPaginated) {
             const processed = process(page[options.dataField]);
@@ -111,7 +107,7 @@ module.exports = function () {
               [options.dataField]: processed
             });
           }
-
+          
           return process(page);
         };
       };

--- a/src/strategies.js
+++ b/src/strategies.js
@@ -48,7 +48,13 @@ module.exports = function () {
       const onCreated = eventData => {
         return page => {
           const isPaginated = !!page[options.dataField];
-          const process = data => data.concat(eventData);
+          const process = data => {
+            // We should not add object twice
+            const exists = data.find(current =>
+              eventData[options.idField] === current[options.idField]
+            )
+            return (exists ? data : data.concat(eventData));
+          }
 
           if (isPaginated) {
             return Object.assign({}, page, {
@@ -85,6 +91,16 @@ module.exports = function () {
             data.filter(current => eventData[options.idField] !== current[options.idField])
               .concat(eventData)
               .filter(matches);
+          /* Why this does not actually work ?
+          const process = data => {
+            // Remove previous matching object if any
+            let newData = data.filter(current => eventData[options.idField] !== current[options.idField]);
+            // We should not add object we are not already aware of however
+            if (newData.length < data.length) {
+              newData = newData.concat(eventData);
+            }
+            return newData.filter(matches);
+          }*/
 
           if (isPaginated) {
             const processed = process(page[options.dataField]);


### PR DESCRIPTION
Fix for https://github.com/feathersjs-ecosystem/feathers-reactive/issues/182.

Updating the `onCreated ` listener seems to be sufficent to fix it.

However, adding a similar check for the `onUpdated ` listener should work as well. However, it appears to break some tests. Could you please have a look to this [commented code](https://github.com/feathersjs-ecosystem/feathers-reactive/compare/master...kalisio:master#diff-a67e545a00d652112e20ed905b03d048f4b0c0741a845a0809bf0c14d70bc051R94) please ?

Thanks