### PR TITLE
Fix integration tests

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -81,8 +81,7 @@ describe('feathers-reactive integration', () => {
     });
 
     await app.service('messages').remove(message.id);
-
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await new Promise(resolve => client.service('messages').once('removed', resolve));
 
     listener.unsubscribe();
     // We should have 5 calls: first find + 4 events

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -4,6 +4,7 @@ import socketio from '@feathersjs/socketio';
 import socketioClient from '@feathersjs/socketio-client';
 import io from 'socket.io-client';
 import memory from 'feathers-memory';
+import { firstValueFrom } from 'rxjs';
 import rx from '../src';
 
 const app = feathers()
@@ -24,29 +25,30 @@ describe('feathers-reactive integration', () => {
       .configure(socketioClient(socket))
       .configure(rx({ idField: 'id' }));
 
-    let callCount = 0
+    let callCount = 0;
     const listener = client.service('messages')
       .watch({ listStrategy: 'smart' })
       .find({ query: {} })
       .subscribe(messages => {
         assert.ok(messages);
-        callCount++
+        callCount++;
       });
-    await client.service('messages').create({
+
+    const message = await client.service('messages').create({
       text: 'A test message'
     });
-    await client.service('messages').patch(0, {
+    await client.service('messages').patch(message.id, {
       text: 'A patched test message'
     });
-    await client.service('messages').update(0, {
-      id: 0,
+    await client.service('messages').update(message.id, {
+      id: message.id,
       text: 'An updated test message'
     });
-    await client.service('messages').remove(0);
-    listener.unsubscribe()
+    await client.service('messages').remove(message.id);
+    listener.unsubscribe();
     // We should have 5 calls: first find + 4 events
     assert.equal(callCount, 5);
-  }).timeout(5000);
+  });
 
   it('works with a client Feathers app listening for service operations', async () => {
     const socket = io('http://localhost:3030');
@@ -54,29 +56,38 @@ describe('feathers-reactive integration', () => {
       .configure(socketioClient(socket))
       .configure(rx({ idField: 'id' }));
 
-    let callCount = 0
-    const listener = client.service('messages')
+    let callCount = 0;
+    const find = client.service('messages')
       .watch({ listStrategy: 'smart' })
-      .find({ query: {} })
-      .subscribe(messages => {
-        assert.ok(messages);
-        callCount++
-      });
-    await app.service('messages').create({
+      .find({ query: {} });
+    const listener = find.subscribe(messages => {
+      assert.ok(messages);
+      callCount++;
+    });
+
+    // We need to wait for the first (empty list) response to avoid timing issues
+    await firstValueFrom(find);
+
+    const message = await app.service('messages').create({
       text: 'A test message'
     });
-    await app.service('messages').patch(1, {
+
+    await app.service('messages').patch(message.id, {
       text: 'A patched test message'
     });
-    await app.service('messages').update(1, {
+    await app.service('messages').update(message.id, {
       id: 1,
       text: 'An updated test message'
     });
-    await app.service('messages').remove(1);
-    listener.unsubscribe()
+
+    await app.service('messages').remove(message.id);
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    listener.unsubscribe();
     // We should have 5 calls: first find + 4 events
     assert.equal(callCount, 5);
-  }).timeout(5000);
+  });
 
   it('works with multiple client Feathers apps', async () => {
     const socket = io('http://localhost:3030');
@@ -87,36 +98,47 @@ describe('feathers-reactive integration', () => {
       .configure(socketioClient(socket))
       .configure(rx({ idField: 'id' }));
 
-    let callCount1 = 0, callCount2 = 0
-    const listener1 = client1.service('messages')
+    let callCount1 = 0;
+    let callCount2 = 0;
+
+    const find1 = client1.service('messages')
       .watch({ listStrategy: 'smart' })
-      .find({ query: {} })
-      .subscribe(messages => {
-        assert.ok(messages);
-        callCount1++
-      });
-    const listener2 = client2.service('messages')
+      .find({ query: {} });
+    const listener1 = find1.subscribe(messages => {
+      assert.ok(messages);
+      callCount1++;
+    });
+    const find2 = client2.service('messages')
       .watch({ listStrategy: 'smart' })
-      .find({ query: {} })
-      .subscribe(messages => {
-        assert.ok(messages);
-        callCount2++
-      });
-    await client1.service('messages').create({
+      .find({ query: {} });
+    const listener2 = find2.subscribe(messages => {
+      assert.ok(messages);
+      callCount2++;
+    });
+
+    // Wait for the first find results to return
+    await firstValueFrom(find1);
+    await firstValueFrom(find2);
+
+    const message = await client1.service('messages').create({
       text: 'A test message'
     });
-    await client1.service('messages').patch(2, {
+
+    await client1.service('messages').patch(message.id, {
       text: 'A patched test message'
     });
-    await client2.service('messages').update(2, {
+
+    await client2.service('messages').update(message.id, {
       id: 2,
       text: 'An updated test message'
     });
-    await client2.service('messages').remove(2);
-    listener1.unsubscribe()
-    listener2.unsubscribe()
+
+    await client2.service('messages').remove(message.id);
+
+    listener1.unsubscribe();
+    listener2.unsubscribe();
     // We should have 5 calls: first find + 4 events
     assert.equal(callCount1, 5);
     assert.equal(callCount2, 5);
-  }).timeout(5000);
+  });
 });


### PR DESCRIPTION
This pull request is a follow up to the updated integration tests by @claustres in https://github.com/feathersjs-ecosystem/feathers-reactive/pull/192

The problem wasn't in feathers-reactive but in the tests. When creating messages on the server or on another client, the observable never got triggered because the tests finished before any of the events propagated to the client instance. The solution was to wait for the first return value on the client and then run the tests.