### PR TITLE
Specify module type for project

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.10.0",
   "homepage": "https://github.com/feathersjs-ecosystem/feathers-reactive",
   "main": "src/index.js",
+  "type": "module",
   "keywords": [
     "feathers",
     "feathers-plugin"


### PR DESCRIPTION
This allows use of the `import` statement.

Fixes: https://github.com/feathersjs-ecosystem/feathers-reactive/issues/193 https://github.com/feathersjs-ecosystem/feathers-reactive/issues/203